### PR TITLE
Add commit hash to DebugUI

### DIFF
--- a/project/src/DebugUI.gd
+++ b/project/src/DebugUI.gd
@@ -1,9 +1,21 @@
 extends Control
 
 @onready var cap_count_label = $HBoxContainer/CapCountLabel
+@onready var commit_hash_label = $CommitHashContainer/CommitHashLabel
 
 func _ready():
 	Signals.connect("cap_count_updated", Callable(self, "_on_cap_count_updated"))
+	commit_hash_label.text = get_current_git_revision()
 
 func _on_cap_count_updated(count: int):
 	cap_count_label.text = str(count)
+
+func get_current_git_revision():
+	var output = []
+	var exit_code = OS.execute("git", ["rev-parse", "--short", "HEAD"], output)
+	if exit_code == 0 and output.size() > 0:
+		return output[0]
+	else:
+		printerr("Failed to get the git hash.")
+		push_error("Failed to get git hash.")
+		return ""

--- a/project/src/DebugUI.tscn
+++ b/project/src/DebugUI.tscn
@@ -21,3 +21,18 @@ text = "Cap count:"
 [node name="CapCountLabel" type="Label" parent="HBoxContainer"]
 layout_mode = 2
 text = "0"
+
+[node name="CommitHashContainer" type="HBoxContainer" parent="."]
+layout_mode = 0
+offset_left = 266.0
+offset_right = 403.0
+offset_bottom = 40.0
+alignment = 2
+
+[node name="CommitHashName" type="Label" parent="CommitHashContainer"]
+layout_mode = 2
+text = "Commmit hash:"
+
+[node name="CommitHashLabel" type="Label" parent="CommitHashContainer"]
+layout_mode = 2
+text = "0"


### PR DESCRIPTION
This makes the commit hash visibile in the DebugUI. This allows the hash to be seen in recordings.
This allows us to corrolate a recording with a specific commit version.

Closes #104 


Example correlation between the commit in the PR and the commit shown in the DebugUI:


![pr0105-example-coorelation](https://github.com/loteque/wasteland-warrior/assets/69282314/9354a248-5021-4faa-9c22-ba2a79ef141b)

![image](https://github.com/loteque/wasteland-warrior/assets/23508546/03c69a26-1eb1-41fa-9205-a182c682b291)

## Video



https://github.com/loteque/wasteland-warrior/assets/69282314/1f164fd2-dd4f-46a6-b68e-14e577d98861


https://github.com/loteque/wasteland-warrior/assets/23508546/4caa3276-30ea-4fd0-9f2f-af5f53dbcc8d
