### PR TITLE
Refactor PlayerController into components

### DIFF
--- a/project/src/HurtBox.gd
+++ b/project/src/HurtBox.gd
@@ -1,0 +1,12 @@
+extends Area2D
+
+@export var hurt_group: String
+
+signal took_damage(value: int)
+
+func _on_HurtBox_body_entered(body):
+	if body.is_in_group(hurt_group):
+		emit_signal("took_damage", body.damage)
+
+func _on_invincibility_component_invincibility_toggled(is_invincible):
+	set_monitoring(not is_invincible)

--- a/project/src/PlayerController.gd
+++ b/project/src/PlayerController.gd
@@ -4,18 +4,10 @@ extends CharacterBody2D
 @export var projectile_pool: ObjectPool
 @export var attack_interval := 30
 @export var projectile_speed := 100
-
-var is_invincible = false
-@onready var iframe_timer = $IFrameTimer 
-@onready var sprite = $Sprite2D
+@onready var sprite = $PlayerSpriteComponent 
 @onready var sprite_fx_animations = sprite.get_node("FXAnimationPlayer")
 @onready var projectile_start = $ProjectileStart
 @onready var projectile_target = $ProjectileTarget
-@onready var health_component: HealthComponent = $HealthComponent
-
-
-func _ready():
-	$Sprite2D.self_modulate = Color(1, 1, 1)
 
 func _physics_process(_delta):
 	
@@ -60,29 +52,6 @@ func is_facing_left():
 func face_right():
 	global_transform.x.x = 1
 
-func _on_HurtBox_body_entered(body):
-	if body.is_in_group("CanHurtPlayer") and !is_invincible:
-		take_damage(body.damage)
-		make_temporarily_invincible()
-
-func take_damage(amount):
-	Signals.emit_signal("player_hit")
-	sprite_fx_animations.play("Hit Flash")
-	health_component.damage(amount)
-
-func make_temporarily_invincible():
-	is_invincible = true
-	start_iframe_timer()
-
-func start_iframe_timer():
-	iframe_timer.start()
-	
-func _on_IFrameTimer_timeout():
-	make_vincible()
-
-func make_vincible():
-	is_invincible = false
-
 func rotate_180(radians: float):
 	return radians + PI
 
@@ -95,5 +64,4 @@ func attack():
 	
 	bullet.update(projectile_speed, facing_angle)
 	bullet.global_position = projectile_start.global_position
-#	get_tree().root.add_child(bullet)
 	Signals.emit_signal("projectile_shot")

--- a/project/src/PlayerController.tscn
+++ b/project/src/PlayerController.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=35 format=3 uid="uid://durlan6er57t1"]
+[gd_scene load_steps=39 format=3 uid="uid://durlan6er57t1"]
 
 [ext_resource type="Script" path="res://src/PlayerController.gd" id="1"]
 [ext_resource type="Script" path="res://src/ObjectPool.gd" id="2_pic7l"]
@@ -7,6 +7,15 @@
 [ext_resource type="Shader" path="res://src/mobs/hit_flash_red.gdshader" id="6"]
 [ext_resource type="Texture2D" uid="uid://bwei2t7nq51h6" path="res://assets/char/onehanded.png" id="6_dfkmd"]
 [ext_resource type="PackedScene" uid="uid://bk3scw1w2hue1" path="res://src/Projectile.tscn" id="8_dxdn3"]
+[ext_resource type="Script" path="res://src/PlayerSpriteComponent.gd" id="8_wrtxp"]
+[ext_resource type="Script" path="res://src/HurtBox.gd" id="9_2l243"]
+[ext_resource type="PackedScene" uid="uid://bwv73goppw5ma" path="res://src/components/InvincibilityComponent.tscn" id="10_x4bqf"]
+[ext_resource type="Script" path="res://src/SoundComponent.gd" id="12_vlh10"]
+[ext_resource type="AudioStream" uid="uid://6x8gja2ue1ql" path="res://assets/audio/hit.wav" id="13_8dqs5"]
+
+[sub_resource type="CapsuleShape2D" id="1"]
+radius = 2.0
+height = 8.0
 
 [sub_resource type="CapsuleShape2D" id="9"]
 radius = 5.0
@@ -170,8 +179,6 @@ animations = [{
 "speed": 10.0
 }]
 
-[sub_resource type="AnimationNodeStateMachine" id="22"]
-
 [sub_resource type="Animation" id="4"]
 resource_name = "Hit Flash"
 tracks/0/type = "value"
@@ -232,15 +239,20 @@ _data = {
 "RESET": SubResource("5")
 }
 
-[sub_resource type="CapsuleShape2D" id="1"]
-radius = 2.0
-height = 8.0
-
 [node name="PlayerController" type="CharacterBody2D" node_paths=PackedStringArray("projectile_pool") groups=["player"]]
 script = ExtResource("1")
 speed = 100
 projectile_pool = NodePath("ProjectilePool")
 projectile_speed = 200
+
+[node name="HurtBox" type="Area2D" parent="."]
+script = ExtResource("9_2l243")
+hurt_group = "CanHurtPlayer"
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="HurtBox"]
+position = Vector2(-2, 0)
+scale = Vector2(3, 3)
+shape = SubResource("1")
 
 [node name="ProjectilePool" type="Node" parent="."]
 script = ExtResource("2_pic7l")
@@ -248,7 +260,7 @@ object_scene = ExtResource("8_dxdn3")
 
 [node name="HealthComponent" type="Node" parent="."]
 script = ExtResource("3")
-MAX_HEALTH = 20.0
+MAX_HEALTH = 3.0
 
 [node name="PickupShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(-1, 0)
@@ -265,13 +277,14 @@ position = Vector2(20, -3)
 [node name="CollisionShape2D" type="CollisionShape2D" parent="ProjectileTarget/Area3D"]
 shape = SubResource("8")
 
-[node name="Sprite2D" type="AnimatedSprite2D" parent="."]
+[node name="PlayerSpriteComponent" type="AnimatedSprite2D" parent="."]
 texture_filter = 1
 material = SubResource("3")
 position = Vector2(-1, 0)
 sprite_frames = SubResource("SpriteFrames_uprer")
 animation = &"death"
 offset = Vector2(-10, 0)
+script = ExtResource("8_wrtxp")
 metadata/_aseprite_wizard_config_ = {
 "layer": "onehanded",
 "o_ex_p": "",
@@ -282,24 +295,24 @@ metadata/_aseprite_wizard_config_ = {
 "source": "res://assets/Player.aseprite"
 }
 
-[node name="AnimationTree" type="AnimationTree" parent="Sprite2D"]
-tree_root = SubResource("22")
-
-[node name="FXAnimationPlayer" type="AnimationPlayer" parent="Sprite2D"]
+[node name="FXAnimationPlayer" type="AnimationPlayer" parent="PlayerSpriteComponent"]
 libraries = {
 "": SubResource("AnimationLibrary_1qsx0")
 }
 
 [node name="MobSpawner" parent="." instance=ExtResource("4")]
 
-[node name="IFrameTimer" type="Timer" parent="."]
+[node name="InvincibilityComponent" parent="." instance=ExtResource("10_x4bqf")]
 
-[node name="HurtBox" type="Area2D" parent="."]
+[node name="SoundComponent" type="Node" parent="."]
+script = ExtResource("12_vlh10")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="HurtBox"]
-position = Vector2(-2, 0)
-scale = Vector2(3, 3)
-shape = SubResource("1")
+[node name="HitSound2D" type="AudioStreamPlayer2D" parent="SoundComponent"]
+stream = ExtResource("13_8dqs5")
 
-[connection signal="timeout" from="IFrameTimer" to="." method="_on_IFrameTimer_timeout"]
-[connection signal="body_entered" from="HurtBox" to="." method="_on_HurtBox_body_entered"]
+[connection signal="body_entered" from="HurtBox" to="HurtBox" method="_on_HurtBox_body_entered"]
+[connection signal="took_damage" from="HurtBox" to="HealthComponent" method="_on_hurt_box_took_damage"]
+[connection signal="took_damage" from="HurtBox" to="PlayerSpriteComponent" method="_on_hurt_box_took_damage"]
+[connection signal="took_damage" from="HurtBox" to="InvincibilityComponent" method="_on_hurt_box_took_damage"]
+[connection signal="took_damage" from="HurtBox" to="SoundComponent" method="_on_hurt_box_took_damage"]
+[connection signal="invincibility_toggled" from="InvincibilityComponent" to="HurtBox" method="_on_invincibility_component_invincibility_toggled"]

--- a/project/src/PlayerSpriteComponent.gd
+++ b/project/src/PlayerSpriteComponent.gd
@@ -1,0 +1,6 @@
+extends AnimatedSprite2D
+
+@onready var sprite_fx_animations = $FXAnimationPlayer
+
+func _on_hurt_box_took_damage(value):
+	sprite_fx_animations.play("Hit Flash")

--- a/project/src/SoundComponent.gd
+++ b/project/src/SoundComponent.gd
@@ -1,0 +1,6 @@
+extends Node
+
+@onready var hit_sound = $HitSound2D
+
+func _on_hurt_box_took_damage(value):
+	hit_sound.play()

--- a/project/src/components/HealthComponent.gd
+++ b/project/src/components/HealthComponent.gd
@@ -23,5 +23,13 @@ func heal(value):
 	set_health(health + value)
 
 func damage(value):
-	print("Took damage: " + str(value))
 	set_health(health - value)
+	if health <= 0:
+		die()
+	print("Took damage: " + str(value))
+	
+func die():
+	print("died")
+
+func _on_hurt_box_took_damage(value):
+	damage(value)

--- a/project/src/components/InvincibilityComponent.gd
+++ b/project/src/components/InvincibilityComponent.gd
@@ -1,0 +1,18 @@
+extends Node
+class_name InvincibilityComponent
+
+@export var invincibility_duration := 2.0
+
+@onready var timer: Timer = $Timer
+
+signal invincibility_toggled(is_invincible)
+
+func enable_invincibility():
+	emit_signal("invincibility_toggled", true)
+	timer.start(invincibility_duration)
+
+func _on_Timer_timeout():
+	emit_signal("invincibility_toggled", false)
+
+func _on_hurt_box_took_damage(value):
+	enable_invincibility()

--- a/project/src/components/InvincibilityComponent.tscn
+++ b/project/src/components/InvincibilityComponent.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=2 format=3 uid="uid://bwv73goppw5ma"]
+
+[ext_resource type="Script" path="res://src/components/InvincibilityComponent.gd" id="1_qkj0g"]
+
+[node name="InvincibilityComponent" type="Node2D"]
+script = ExtResource("1_qkj0g")
+
+[node name="Timer" type="Timer" parent="."]
+
+[connection signal="timeout" from="Timer" to="." method="_on_Timer_timeout"]


### PR DESCRIPTION
Pull out funcitonality from PlayerController into:
* HurtBoxComponent
* InvincibilityComponent
* SoundComponent
* HealthComponent

Use Signals to communicate between components.

## Scene Tree

![pr0130-scenetree](https://github.com/loteque/wasteland-warrior/assets/69282314/29604930-cd09-410d-9d73-fb2694ab54fc)


![image](https://github.com/loteque/wasteland-warrior/assets/23508546/e40629bb-ec49-46ab-a279-3f15117a22f0)


Closes #115