### PR TITLE
Play death animation when the player dies

### DIFF
--- a/project/src/PlayerController.gd
+++ b/project/src/PlayerController.gd
@@ -65,3 +65,6 @@ func attack():
 	bullet.update(projectile_speed, facing_angle)
 	bullet.global_position = projectile_start.global_position
 	Signals.emit_signal("projectile_shot")
+
+func _on_health_component_died():
+	set_physics_process(false)

--- a/project/src/PlayerController.tscn
+++ b/project/src/PlayerController.tscn
@@ -128,7 +128,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_wrhyu")
 }],
-"loop": true,
+"loop": false,
 "name": &"death",
 "speed": 10.0
 }, {
@@ -315,4 +315,6 @@ stream = ExtResource("13_8dqs5")
 [connection signal="took_damage" from="HurtBox" to="PlayerSpriteComponent" method="_on_hurt_box_took_damage"]
 [connection signal="took_damage" from="HurtBox" to="InvincibilityComponent" method="_on_hurt_box_took_damage"]
 [connection signal="took_damage" from="HurtBox" to="SoundComponent" method="_on_hurt_box_took_damage"]
+[connection signal="died" from="HealthComponent" to="." method="_on_health_component_died"]
+[connection signal="died" from="HealthComponent" to="PlayerSpriteComponent" method="_on_health_component_died"]
 [connection signal="invincibility_toggled" from="InvincibilityComponent" to="HurtBox" method="_on_invincibility_component_invincibility_toggled"]

--- a/project/src/PlayerSpriteComponent.gd
+++ b/project/src/PlayerSpriteComponent.gd
@@ -2,5 +2,8 @@ extends AnimatedSprite2D
 
 @onready var sprite_fx_animations = $FXAnimationPlayer
 
-func _on_hurt_box_took_damage(value):
+func _on_hurt_box_took_damage(_value):
 	sprite_fx_animations.play("Hit Flash")
+
+func _on_health_component_died():
+	play("death")

--- a/project/src/components/HealthComponent.gd
+++ b/project/src/components/HealthComponent.gd
@@ -6,6 +6,8 @@ class_name HealthComponent
 
 @onready var health := MAX_HEALTH: get = get_health, set = set_health
 
+signal died
+
 func set_max_health(value):
 	if value > MIN_HEALTH:
 		MAX_HEALTH = value
@@ -29,7 +31,7 @@ func damage(value):
 	print("Took damage: " + str(value))
 	
 func die():
-	print("died")
+	emit_signal("died")
 
 func _on_hurt_box_took_damage(value):
 	damage(value)

--- a/project/src/components/InvincibilityComponent.tscn
+++ b/project/src/components/InvincibilityComponent.tscn
@@ -6,5 +6,6 @@
 script = ExtResource("1_qkj0g")
 
 [node name="Timer" type="Timer" parent="."]
+one_shot = true
 
 [connection signal="timeout" from="Timer" to="." method="_on_Timer_timeout"]


### PR DESCRIPTION
Also stops player physics process on player death

![pr0132](https://github.com/loteque/wasteland-warrior/assets/69282314/e4c1c9f6-e314-4f81-aa1f-12c5ccc01198)

![2023-10-08_19-02-18](https://github.com/loteque/wasteland-warrior/assets/23508546/aee1e646-d429-4d10-9f0a-8c4d0f82520a)

Fixes #128



## Note

The player can die multiple times. This is related to the fact that collision monitoring with Area2D doesn't work as expected. New issue created to resolve here: 

* #133



