### PR TITLE
Change Canvas Item texture filtering to "Nearest"

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -91,6 +91,7 @@ common/enable_pause_aware_picking=true
 
 [rendering]
 
+textures/canvas_textures/default_texture_filter=0
 environment/defaults/default_clear_color=Color(0.321569, 0.2, 0.247059, 1)
 environment/defaults/default_environment="res://default_env.tres"
 quality/driver/driver_name="GLES2"


### PR DESCRIPTION
Changing the Canvas Item texture filtering to "Nearest" by default will help avoid blurry sprites when adding imported textures to nodes.
![pr0148](https://github.com/loteque/wasteland-warrior/assets/69282314/8406fbae-08d9-4901-bd96-aa0f5e4c85cf)

![image](https://github.com/loteque/wasteland-warrior/assets/14969116/66db016c-8ee6-472d-8f8c-53bfea3a2b1a)

* Closes #145 