### PR TITLE
add snippets cw, gcw for writing configuration warning

### DIFF
--- a/.vscode/wasteland-warriors.code-snippets
+++ b/.vscode/wasteland-warriors.code-snippets
@@ -1,0 +1,41 @@
+{
+
+    // Place your snippets for gdscript here. Each snippet is defined under a snippet name and has a prefix, body and 
+    // description. The prefix is what is used to trigger the snippet and the body will be expanded and inserted. Possible variables are:
+    // $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders. Placeholders with the 
+    // same ids are connected.
+    // Example:
+    // "Print to console": {
+    // 	"prefix": "log",
+    // 	"body": [
+    // 		"console.log('$1');",
+    // 		"$2"
+    // 	],
+    // 	"description": "Log output to console"
+    // }
+    "Export editor warnings": {
+        "prefix": "cw",
+        "body": [
+            "var ${TM_SELECTED_TEXT:$1}_warn: String = '$3'",
+            "@export var ${TM_SELECTED_TEXT:$1}: ${Node: $2}:",
+            "   get:",
+            "       return ${TM_SELECTED_TEXT:$1}",
+            "   set(${TM_SELECTED_TEXT:$1}_value):",
+            "       ${TM_SELECTED_TEXT:$1} = ${TM_SELECTED_TEXT:$1}_value",
+            "       if Engine.is_editor_hint():",
+            "           update_configuration_warnings()"
+        ],
+        "description", "add update_configuration_warnings to setget on export var" 
+    },
+    "_get_configuration_warnings": {
+        "prefix": "gcw",
+        "body": [
+            "func _get_configuration_warnings() -> PackedStringArray:"
+	        "   var properties: Array = [$1]"
+	        "   var warning_strings: Array = [$2]"
+	        "   var warnings: PackedStringArray = ComponentUtils.compile_warnings(properties, warning_strings)"
+	        "   return warnings"
+        ],
+        "description": "add _get_configuration_warnings"
+    }
+}

--- a/project/src/utils/ComponentUtils.gd
+++ b/project/src/utils/ComponentUtils.gd
@@ -17,3 +17,12 @@ func set_component_property(component, property: String, value, deferred: bool =
 			component.set(property, value)
 	
 		print("ComponentUtils: set " + defer + " value: " + str(value) + " on property " + property + " in component " + str(component))
+
+func compile_warnings(properties: Array, warning_strings: Array) -> PackedStringArray:
+	var warnings: PackedStringArray = PackedStringArray()
+	var i: int = 0
+	for property in properties:
+		if not property:
+			warnings.append(warning_strings[i])
+			i += 1 
+	return warnings


### PR DESCRIPTION
* typing cw [tab/(enter)] will insert a preconfigured code snippet.
	* the snippet aids in writing the setget required to update the eitor config warnings.
* typing gcw [tab/(enter)] will insert a preconfigured code snippet.
	* the snippet adds the required callback to get the config warnings on a call to set().
* add a compile_warnings() method to ComponentUtils global required by the gcw snippet.


https://github.com/loteque/wasteland-warrior/assets/69282314/e92c35b9-ba1e-4ab7-9b1e-4f8fbb702855



https://github.com/loteque/wasteland-warrior/assets/69282314/b967f71b-b671-47a8-acfc-3f248b9fbd9c


* closes #159